### PR TITLE
build: Use --release flag for maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<release>17</release>
 					<parameters>true</parameters>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
+					<source>17</source>
+					<target>17</target>					
 					<release>17</release>
 					<parameters>true</parameters>
 				</configuration>


### PR DESCRIPTION
Replaced the <source> and <target> properties with the <release> property in the maven-compiler-plugin configuration.

This is the recommended way to configure the Java version, as it also sets the boot classpath, ensuring proper API compatibility.