### PR TITLE
Add per-client send buffer with backpressure protection for slow clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.17.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <version>3.0.0</version>

--- a/src/main/java/ch/rasc/sse/eventbus/Client.java
+++ b/src/main/java/ch/rasc/sse/eventbus/Client.java
@@ -15,6 +15,8 @@
  */
 package ch.rasc.sse.eventbus;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public class Client {
@@ -26,6 +28,8 @@ public class Client {
 	private volatile long lastTransfer;
 
 	private volatile boolean completeAfterMessage;
+
+	private volatile @Nullable ClientSendBuffer sendBuffer;
 
 	Client(String id, SseEmitter sseEmitter, boolean completeAfterMessage) {
 		this.id = id;
@@ -60,6 +64,14 @@ public class Client {
 
 	boolean isCompleteAfterMessage() {
 		return this.completeAfterMessage;
+	}
+
+	@Nullable ClientSendBuffer sendBuffer() {
+		return this.sendBuffer;
+	}
+
+	void updateSendBuffer(@Nullable ClientSendBuffer sendBuffer) {
+		this.sendBuffer = sendBuffer;
 	}
 
 }

--- a/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
+++ b/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
@@ -131,6 +131,8 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	private final AtomicBoolean draining = new AtomicBoolean();
 
+	private @Nullable SlowClientEvent pendingNotification;
+
 	private volatile @Nullable Thread dispatcherThread;
 
 	ClientSendBuffer(String clientId, int capacity, OverflowPolicy overflowPolicy, EventSink sink,
@@ -184,14 +186,18 @@ final class ClientSendBuffer implements AutoCloseable {
 			if (this.metrics != null) {
 				this.metrics.recordDropped(this.clientId);
 			}
-			notifySlowClient(queueSize, "send buffer full, new event dropped");
+			// Notify on the dispatcher thread so a slow listener cannot block the
+			// shared send worker (head-of-line blocking)
+			setPendingNotification(SlowClientEvent.of(this.clientId, this.overflowPolicy, queueSize, this.capacity,
+					"send buffer full, new event dropped"));
 			return OfferResult.DROPPED;
 		}
 		case DISCONNECT -> {
 			if (this.metrics != null) {
 				this.metrics.recordDisconnected(this.clientId);
 			}
-			notifySlowClient(queueSize, "send buffer full, slow client disconnected");
+			setPendingNotification(SlowClientEvent.of(this.clientId, this.overflowPolicy, queueSize, this.capacity,
+					"send buffer full, slow client disconnected"));
 			closeAndNotifyDisconnect();
 			return OfferResult.DISCONNECTED;
 		}
@@ -199,15 +205,28 @@ final class ClientSendBuffer implements AutoCloseable {
 		}
 	}
 
-	private void notifySlowClient(int queueSize, String detail) {
+	private void setPendingNotification(SlowClientEvent slowClientEvent) {
+		synchronized (this) {
+			this.pendingNotification = slowClientEvent;
+		}
+	}
+
+	private @Nullable SlowClientEvent takePendingNotification() {
+		synchronized (this) {
+			SlowClientEvent pending = this.pendingNotification;
+			this.pendingNotification = null;
+			return pending;
+		}
+	}
+
+	private void notifyListener(SlowClientEvent slowClientEvent) {
 		SlowClientListener slowClientListener = this.listener;
 		if (slowClientListener != null) {
 			if (this.metrics != null) {
 				this.metrics.recordNotification(this.clientId);
 			}
 			try {
-				slowClientListener.onSlowClient(
-						SlowClientEvent.of(this.clientId, this.overflowPolicy, queueSize, this.capacity, detail));
+				slowClientListener.onSlowClient(slowClientEvent);
 			}
 			catch (RuntimeException ex) {
 				// listener failures must not affect event delivery
@@ -218,6 +237,10 @@ final class ClientSendBuffer implements AutoCloseable {
 	private void dispatchLoop() {
 		try {
 			while (!Thread.currentThread().isInterrupted()) {
+				SlowClientEvent pending = takePendingNotification();
+				if (pending != null) {
+					notifyListener(pending);
+				}
 				ClientEvent event = this.queue.poll(200, TimeUnit.MILLISECONDS);
 				if (event == null) {
 					if (this.closed.get() || this.draining.get()) {
@@ -302,6 +325,14 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	private void closeAndNotifyDisconnect() {
 		if (this.closed.compareAndSet(false, true)) {
+			// Deliver a pending slow-client notification that the dispatcher thread may no
+			// longer have a chance to process after being interrupted. Synchronous
+			// delivery here is acceptable because this path runs once per disconnected
+			// client, not on every overflow.
+			SlowClientEvent pending = takePendingNotification();
+			if (pending != null) {
+				notifyListener(pending);
+			}
 			interruptDispatcher();
 			Runnable disconnect = this.onDisconnect;
 			if (disconnect != null) {

--- a/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
+++ b/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
@@ -245,20 +245,27 @@ final class ClientSendBuffer implements AutoCloseable {
 	}
 
 	/**
-	 * Waits until the dispatcher thread has delivered all currently queued events, or
-	 * until the timeout elapses. After this method returns the buffer can be closed
-	 * without losing events. Idempotent.
-	 * @param timeoutMillis maximum time to wait for the queue to drain
+	 * Starts draining: the dispatcher thread keeps delivering already queued events and
+	 * exits once the queue is empty. Idempotent. Call {@link #awaitDrained(long)} to
+	 * wait for the dispatcher to finish.
 	 */
-	void drain(long timeoutMillis) {
+	void startDraining() {
 		this.draining.set(true);
+	}
+
+	/**
+	 * Waits until the dispatcher thread has exited (queue drained), or until the
+	 * deadline elapses. A timed-out dispatcher is interrupted so the buffer can be
+	 * closed without losing control.
+	 * @param deadlineNanos absolute deadline in nanoseconds
+	 */
+	void awaitDrained(long deadlineNanos) {
 		Thread thread = this.dispatcherThread;
 		if (thread == null || thread == Thread.currentThread()) {
 			return;
 		}
-		long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
 		try {
-			while (thread.isAlive() && System.nanoTime() < deadline) {
+			while (thread.isAlive() && System.nanoTime() < deadlineNanos) {
 				Thread.sleep(10);
 			}
 			if (thread.isAlive()) {
@@ -268,6 +275,17 @@ final class ClientSendBuffer implements AutoCloseable {
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		}
+	}
+
+	/**
+	 * Starts draining and waits until the dispatcher thread has delivered all currently
+	 * queued events, or until the timeout elapses. After this method returns the buffer
+	 * can be closed without losing events.
+	 * @param timeoutMillis maximum time to wait for the queue to drain
+	 */
+	void drain(long timeoutMillis) {
+		startDraining();
+		awaitDrained(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
 	}
 
 	/**

--- a/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
+++ b/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+/**
+ * Bounded per-client send buffer with a dedicated dispatcher thread.
+ * <p>
+ * When enabled through {@link SseEventBusConfigurer#clientSendBufferCapacity()} every
+ * client gets its own bounded queue. A dedicated daemon thread takes events from the
+ * queue and writes them to the client's {@code SseEmitter}. This prevents slow clients
+ * from blocking the shared send workers (head-of-line blocking).
+ * <p>
+ * When the queue is full the configured {@link OverflowPolicy} is applied:
+ * <ul>
+ * <li>{@link OverflowPolicy#DROP}: the new event is dropped, the connection stays
+ * open.</li>
+ * <li>{@link OverflowPolicy#DISCONNECT}: the connection is closed and the client is
+ * unregistered through the {@code onDisconnect} callback.</li>
+ * </ul>
+ * In both cases {@link SlowClientListener} is notified and Micrometer metrics are
+ * recorded when configured.
+ */
+final class ClientSendBuffer implements AutoCloseable {
+
+	/**
+	 * Writes an event to the underlying SSE connection.
+	 */
+	@FunctionalInterface
+	interface EventSink {
+
+		void send(SseEventBuilder event) throws IOException;
+
+	}
+
+	private final String clientId;
+
+	private final int capacity;
+
+	private final OverflowPolicy overflowPolicy;
+
+	private final BlockingQueue<SseEventBuilder> queue;
+
+	private final EventSink sink;
+
+	private final @Nullable Runnable onDisconnect;
+
+	private final @Nullable SlowClientListener listener;
+
+	private final @Nullable SseBackpressureMetrics metrics;
+
+	private final AtomicBoolean closed = new AtomicBoolean();
+
+	private volatile @Nullable Thread dispatcherThread;
+
+	ClientSendBuffer(String clientId, int capacity, OverflowPolicy overflowPolicy, EventSink sink,
+			@Nullable Runnable onDisconnect, @Nullable SlowClientListener listener,
+			@Nullable SseBackpressureMetrics metrics) {
+		this.clientId = Objects.requireNonNull(clientId, "clientId");
+		if (capacity <= 0) {
+			throw new IllegalArgumentException("clientSendBufferCapacity must be > 0");
+		}
+		this.capacity = capacity;
+		this.overflowPolicy = Objects.requireNonNull(overflowPolicy, "overflowPolicy");
+		this.queue = new LinkedBlockingQueue<>(capacity);
+		this.sink = Objects.requireNonNull(sink, "sink");
+		this.onDisconnect = onDisconnect;
+		this.listener = listener;
+		this.metrics = metrics;
+	}
+
+	/**
+	 * Starts the dedicated dispatcher thread. Idempotent.
+	 */
+	void start() {
+		if (this.closed.get() || this.dispatcherThread != null) {
+			return;
+		}
+		Thread thread = new Thread(this::dispatchLoop, "sse-client-send-" + this.clientId);
+		thread.setDaemon(true);
+		this.dispatcherThread = thread;
+		thread.start();
+	}
+
+	/**
+	 * Attempts to enqueue an event for this client.
+	 * @param event the SSE event to enqueue
+	 * @return {@code true} when the event was accepted, {@code false} when it was
+	 * dropped or the buffer is closed
+	 */
+	boolean offer(SseEventBuilder event) {
+		if (this.closed.get()) {
+			return false;
+		}
+		if (this.queue.offer(event)) {
+			return true;
+		}
+		int queueSize = this.queue.size();
+		if (this.metrics != null) {
+			this.metrics.recordOverflow(this.clientId);
+		}
+		switch (this.overflowPolicy) {
+		case DROP -> {
+			if (this.metrics != null) {
+				this.metrics.recordDropped(this.clientId);
+			}
+			notifySlowClient(queueSize, "send buffer full, new event dropped");
+			return false;
+		}
+		case DISCONNECT -> {
+			if (this.metrics != null) {
+				this.metrics.recordDisconnected(this.clientId);
+			}
+			notifySlowClient(queueSize, "send buffer full, slow client disconnected");
+			closeAndNotifyDisconnect();
+			return false;
+		}
+		default -> throw new IllegalStateException("Unsupported overflow policy: " + this.overflowPolicy);
+		}
+	}
+
+	private void notifySlowClient(int queueSize, String detail) {
+		SlowClientListener slowClientListener = this.listener;
+		if (slowClientListener != null) {
+			if (this.metrics != null) {
+				this.metrics.recordNotification(this.clientId);
+			}
+			try {
+				slowClientListener.onSlowClient(
+						SlowClientEvent.of(this.clientId, this.overflowPolicy, queueSize, this.capacity, detail));
+			}
+			catch (RuntimeException ex) {
+				// listener failures must not affect event delivery
+			}
+		}
+	}
+
+	private void dispatchLoop() {
+		try {
+			while (!this.closed.get()) {
+				SseEventBuilder event = this.queue.poll(200, TimeUnit.MILLISECONDS);
+				if (event == null) {
+					continue;
+				}
+				this.sink.send(event);
+			}
+		}
+		catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+		}
+		catch (Exception ex) {
+			// the connection is gone, close the buffer
+			closeAndNotifyDisconnect();
+		}
+	}
+
+	/**
+	 * Closes the buffer without firing the disconnect callback. Used when the client is
+	 * re-registered or unregistered through the regular lifecycle.
+	 */
+	@Override
+	public void close() {
+		if (this.closed.compareAndSet(false, true)) {
+			interruptDispatcher();
+		}
+	}
+
+	private void closeAndNotifyDisconnect() {
+		if (this.closed.compareAndSet(false, true)) {
+			interruptDispatcher();
+			Runnable disconnect = this.onDisconnect;
+			if (disconnect != null) {
+				try {
+					disconnect.run();
+				}
+				catch (RuntimeException ex) {
+					// ignore disconnect callback failures
+				}
+			}
+		}
+	}
+
+	private void interruptDispatcher() {
+		Thread thread = this.dispatcherThread;
+		if (thread != null) {
+			thread.interrupt();
+		}
+	}
+
+	int queueSize() {
+		return this.queue.size();
+	}
+
+	int capacity() {
+		return this.capacity;
+	}
+
+	boolean isClosed() {
+		return this.closed.get();
+	}
+
+	String clientId() {
+		return this.clientId;
+	}
+
+}

--- a/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
+++ b/src/main/java/ch/rasc/sse/eventbus/ClientSendBuffer.java
@@ -42,8 +42,42 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEvent
  * </ul>
  * In both cases {@link SlowClientListener} is notified and Micrometer metrics are
  * recorded when configured.
+ * <p>
+ * Delivery accounting happens on the dispatcher thread: {@link DeliveryListener} is
+ * invoked after the event was actually written to the {@code SseEmitter} (or after a
+ * send failure), so an enqueued event is never reported as delivered before the sink
+ * has run.
  */
 final class ClientSendBuffer implements AutoCloseable {
+
+	/**
+	 * Result of an {@link #offer(ClientEvent)} call.
+	 */
+	enum OfferResult {
+
+		/**
+		 * The event was enqueued; delivery is reported asynchronously.
+		 */
+		ACCEPTED,
+
+		/**
+		 * The queue was full and the event was dropped by the
+		 * {@link OverflowPolicy#DROP} policy.
+		 */
+		DROPPED,
+
+		/**
+		 * The queue was full and the slow client was disconnected by the
+		 * {@link OverflowPolicy#DISCONNECT} policy.
+		 */
+		DISCONNECTED,
+
+		/**
+		 * The buffer is already closed, the event was not enqueued.
+		 */
+		CLOSED
+
+	}
 
 	/**
 	 * Writes an event to the underlying SSE connection.
@@ -55,15 +89,37 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	}
 
+	/**
+	 * Delivery accounting callback, invoked on the dispatcher thread.
+	 */
+	interface DeliveryListener {
+
+		/**
+		 * Called after the event was successfully written to the connection.
+		 * @param event the delivered event
+		 */
+		void delivered(ClientEvent event);
+
+		/**
+		 * Called after writing the event failed.
+		 * @param event the failed event
+		 * @param exception the failure cause
+		 */
+		void failed(ClientEvent event, Exception exception);
+
+	}
+
 	private final String clientId;
 
 	private final int capacity;
 
 	private final OverflowPolicy overflowPolicy;
 
-	private final BlockingQueue<SseEventBuilder> queue;
+	private final BlockingQueue<ClientEvent> queue;
 
 	private final EventSink sink;
+
+	private final DeliveryListener deliveryListener;
 
 	private final @Nullable Runnable onDisconnect;
 
@@ -73,10 +129,12 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	private final AtomicBoolean closed = new AtomicBoolean();
 
+	private final AtomicBoolean draining = new AtomicBoolean();
+
 	private volatile @Nullable Thread dispatcherThread;
 
 	ClientSendBuffer(String clientId, int capacity, OverflowPolicy overflowPolicy, EventSink sink,
-			@Nullable Runnable onDisconnect, @Nullable SlowClientListener listener,
+			DeliveryListener deliveryListener, @Nullable Runnable onDisconnect, @Nullable SlowClientListener listener,
 			@Nullable SseBackpressureMetrics metrics) {
 		this.clientId = Objects.requireNonNull(clientId, "clientId");
 		if (capacity <= 0) {
@@ -86,6 +144,7 @@ final class ClientSendBuffer implements AutoCloseable {
 		this.overflowPolicy = Objects.requireNonNull(overflowPolicy, "overflowPolicy");
 		this.queue = new LinkedBlockingQueue<>(capacity);
 		this.sink = Objects.requireNonNull(sink, "sink");
+		this.deliveryListener = Objects.requireNonNull(deliveryListener, "deliveryListener");
 		this.onDisconnect = onDisconnect;
 		this.listener = listener;
 		this.metrics = metrics;
@@ -106,16 +165,15 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	/**
 	 * Attempts to enqueue an event for this client.
-	 * @param event the SSE event to enqueue
-	 * @return {@code true} when the event was accepted, {@code false} when it was
-	 * dropped or the buffer is closed
+	 * @param event the event to enqueue
+	 * @return the result of the enqueue attempt
 	 */
-	boolean offer(SseEventBuilder event) {
+	OfferResult offer(ClientEvent event) {
 		if (this.closed.get()) {
-			return false;
+			return OfferResult.CLOSED;
 		}
 		if (this.queue.offer(event)) {
-			return true;
+			return OfferResult.ACCEPTED;
 		}
 		int queueSize = this.queue.size();
 		if (this.metrics != null) {
@@ -127,7 +185,7 @@ final class ClientSendBuffer implements AutoCloseable {
 				this.metrics.recordDropped(this.clientId);
 			}
 			notifySlowClient(queueSize, "send buffer full, new event dropped");
-			return false;
+			return OfferResult.DROPPED;
 		}
 		case DISCONNECT -> {
 			if (this.metrics != null) {
@@ -135,7 +193,7 @@ final class ClientSendBuffer implements AutoCloseable {
 			}
 			notifySlowClient(queueSize, "send buffer full, slow client disconnected");
 			closeAndNotifyDisconnect();
-			return false;
+			return OfferResult.DISCONNECTED;
 		}
 		default -> throw new IllegalStateException("Unsupported overflow policy: " + this.overflowPolicy);
 		}
@@ -159,26 +217,63 @@ final class ClientSendBuffer implements AutoCloseable {
 
 	private void dispatchLoop() {
 		try {
-			while (!this.closed.get()) {
-				SseEventBuilder event = this.queue.poll(200, TimeUnit.MILLISECONDS);
+			while (!Thread.currentThread().isInterrupted()) {
+				ClientEvent event = this.queue.poll(200, TimeUnit.MILLISECONDS);
 				if (event == null) {
+					if (this.closed.get() || this.draining.get()) {
+						break;
+					}
 					continue;
 				}
-				this.sink.send(event);
+				deliver(event);
 			}
 		}
 		catch (InterruptedException ie) {
 			Thread.currentThread().interrupt();
 		}
+	}
+
+	private void deliver(ClientEvent event) {
+		try {
+			this.sink.send(event.createSseEventBuilder());
+			this.deliveryListener.delivered(event);
+		}
 		catch (Exception ex) {
-			// the connection is gone, close the buffer
+			this.deliveryListener.failed(event, ex);
 			closeAndNotifyDisconnect();
 		}
 	}
 
 	/**
-	 * Closes the buffer without firing the disconnect callback. Used when the client is
-	 * re-registered or unregistered through the regular lifecycle.
+	 * Waits until the dispatcher thread has delivered all currently queued events, or
+	 * until the timeout elapses. After this method returns the buffer can be closed
+	 * without losing events. Idempotent.
+	 * @param timeoutMillis maximum time to wait for the queue to drain
+	 */
+	void drain(long timeoutMillis) {
+		this.draining.set(true);
+		Thread thread = this.dispatcherThread;
+		if (thread == null || thread == Thread.currentThread()) {
+			return;
+		}
+		long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+		try {
+			while (thread.isAlive() && System.nanoTime() < deadline) {
+				Thread.sleep(10);
+			}
+			if (thread.isAlive()) {
+				thread.interrupt();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	/**
+	 * Closes the buffer without firing the disconnect callback and without draining the
+	 * queue. Used when the client is re-registered or unregistered through the regular
+	 * lifecycle.
 	 */
 	@Override
 	public void close() {

--- a/src/main/java/ch/rasc/sse/eventbus/OverflowPolicy.java
+++ b/src/main/java/ch/rasc/sse/eventbus/OverflowPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+/**
+ * Policy applied when a client's send buffer is full.
+ * <p>
+ * Slow clients (poor network, slow consumers) cannot keep up with a high frequency
+ * event stream, for example LLM token streaming. Once the per-client bounded send
+ * buffer reaches its capacity this policy decides what happens next.
+ */
+public enum OverflowPolicy {
+
+	/**
+	 * Drop the new event and keep the connection. The client keeps receiving
+	 * subsequent events but may miss some events while it is slow.
+	 */
+	DROP,
+
+	/**
+	 * Disconnect the slow client. The connection is closed and the client is
+	 * unregistered; the application decides whether and when the client reconnects.
+	 */
+	DISCONNECT
+
+}

--- a/src/main/java/ch/rasc/sse/eventbus/SlowClientEvent.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SlowClientEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.time.Instant;
+
+/**
+ * Describes a slow client event. Instances are passed to
+ * {@link SlowClientListener#onSlowClient} when a client's send buffer overflows.
+ *
+ * @param clientId the client identifier
+ * @param policy the overflow policy that was applied
+ * @param queueSize the number of events queued in the client's send buffer when the
+ * overflow happened
+ * @param capacity the configured capacity of the client's send buffer
+ * @param detail a human readable description
+ * @param timestamp the time the event was created
+ */
+public record SlowClientEvent(String clientId, OverflowPolicy policy, int queueSize, int capacity, String detail,
+		Instant timestamp) {
+
+	public static SlowClientEvent of(String clientId, OverflowPolicy policy, int queueSize, int capacity,
+			String detail) {
+		return new SlowClientEvent(clientId, policy, queueSize, capacity, detail, Instant.now());
+	}
+
+}

--- a/src/main/java/ch/rasc/sse/eventbus/SlowClientListener.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SlowClientListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+/**
+ * Callback for slow client events. Invoked when a client's bounded send buffer is
+ * full, either because events were dropped or the client was disconnected.
+ * <p>
+ * Applications can use this to degrade event frequency for the affected client, send
+ * alerts, or throttle publishing.
+ */
+@FunctionalInterface
+public interface SlowClientListener {
+
+	/**
+	 * Called when a client has been detected as slow.
+	 * @param event details about the slow client and the applied policy
+	 */
+	void onSlowClient(SlowClientEvent event);
+
+}

--- a/src/main/java/ch/rasc/sse/eventbus/SseBackpressureMetrics.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseBackpressureMetrics.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer metrics for the per-client send buffer backpressure protection.
+ * <p>
+ * Counters (all prefixed with {@code sse.eventbus.client.buffer}):
+ * <ul>
+ * <li>{@code overflow.total} - number of buffer overflows</li>
+ * <li>{@code dropped.events} - events dropped by the {@link OverflowPolicy#DROP}
+ * policy</li>
+ * <li>{@code disconnected.clients} - clients disconnected by the
+ * {@link OverflowPolicy#DISCONNECT} policy</li>
+ * <li>{@code slow.client.notifications} - slow client callback invocations</li>
+ * </ul>
+ * Gauges:
+ * <ul>
+ * <li>{@code queue.size} (tag {@code clientId}) - current number of queued events per
+ * client</li>
+ * <li>{@code active.clients} - number of clients with an active send buffer</li>
+ * </ul>
+ */
+final class SseBackpressureMetrics {
+
+	private final MeterRegistry registry;
+
+	private final String prefix;
+
+	private final Counter overflows;
+
+	private final Counter droppedEvents;
+
+	private final Counter disconnectedClients;
+
+	private final Counter slowClientNotifications;
+
+	private final Map<String, Gauge> queueGauges = new ConcurrentHashMap<>();
+
+	private final Map<String, Supplier<Number>> strongSuppliers = new ConcurrentHashMap<>();
+
+	SseBackpressureMetrics(MeterRegistry registry) {
+		this.registry = registry;
+		this.prefix = "sse.eventbus.client.buffer";
+		this.overflows = Counter.builder(metric("overflow.total"))
+			.description("Number of per-client send buffer overflows")
+			.register(registry);
+		this.droppedEvents = Counter.builder(metric("dropped.events"))
+			.description("Events dropped because the client send buffer was full")
+			.register(registry);
+		this.disconnectedClients = Counter.builder(metric("disconnected.clients"))
+			.description("Slow clients disconnected because the send buffer was full")
+			.register(registry);
+		this.slowClientNotifications = Counter.builder(metric("slow.client.notifications"))
+			.description("Slow client callback invocations")
+			.register(registry);
+	}
+
+	private String metric(String name) {
+		return this.prefix + "." + name;
+	}
+
+	void recordOverflow(String clientId) {
+		this.overflows.increment();
+	}
+
+	void recordDropped(String clientId) {
+		this.droppedEvents.increment();
+	}
+
+	void recordDisconnected(String clientId) {
+		this.disconnectedClients.increment();
+	}
+
+	void recordNotification(String clientId) {
+		this.slowClientNotifications.increment();
+	}
+
+	void registerQueueGauge(String clientId, Supplier<Number> supplier) {
+		this.strongSuppliers.put("queue:" + clientId, supplier);
+		this.queueGauges.computeIfAbsent(clientId,
+				id -> Gauge.builder(metric("queue.size"), supplier, s -> s.get().doubleValue())
+					.description("Currently queued events in the client's send buffer")
+					.tag("clientId", id)
+					.register(this.registry));
+	}
+
+	void removeQueueGauge(String clientId) {
+		Gauge gauge = this.queueGauges.remove(clientId);
+		if (gauge != null) {
+			this.registry.remove(gauge);
+		}
+		this.strongSuppliers.remove("queue:" + clientId);
+	}
+
+	void registerActiveClientsGauge(Supplier<Number> supplier) {
+		this.strongSuppliers.put("active:clients", supplier);
+		Gauge.builder(metric("active.clients"), supplier, s -> s.get().doubleValue())
+			.description("Number of clients with an active send buffer")
+			.register(this.registry);
+	}
+
+}

--- a/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
@@ -263,23 +263,32 @@ public class SseEventBus {
 				Thread.currentThread().interrupt();
 			}
 
-			for (Client client : this.clients.values()) {
-				closeClientSendBuffer(client);
-			}
-
 			// Flush remaining events after the event loop has stopped
 			List<ClientEvent> remaining = new ArrayList<>();
 			this.sendQueue.drainTo(remaining);
 			for (ClientEvent clientEvent : remaining) {
 				if (clientEvent.getErrorCounter() < this.noOfSendResponseTries) {
-					Exception exception = sendEventToClient(clientEvent);
-					if (exception != null && logger.isDebugEnabled()) {
-						logger.debug("Shutdown flush failed for client " + clientEvent.getClient().getId(), exception);
+					SendResult result = sendEventToClient(clientEvent);
+					if (result.outcome == SendOutcome.FAILED && logger.isDebugEnabled()) {
+						logger.debug("Shutdown flush failed for client " + clientEvent.getClient().getId(),
+								result.exception);
 					}
 				}
 			}
 			if (!remaining.isEmpty()) {
 				logger.info("SseEventBus flushed " + remaining.size() + " pending events on shutdown");
+			}
+
+			// Gracefully deliver events already accepted into per-client send buffers,
+			// then close the buffers
+			for (Client client : this.clients.values()) {
+				ClientSendBuffer buffer = client.sendBuffer();
+				if (buffer != null) {
+					buffer.drain(1000);
+				}
+			}
+			for (Client client : this.clients.values()) {
+				closeClientSendBuffer(client);
 			}
 			logger.info("SseEventBus shut down");
 		}
@@ -720,13 +729,22 @@ public class SseEventBus {
 		}
 
 		notifyAfterEventQueued(clientEvent, firstAttempt);
-		@Nullable Exception exception = sendEventToClient(clientEvent);
-		if (exception == null) {
+		SendResult result = sendEventToClient(clientEvent);
+		switch (result.outcome) {
+		case SENT -> {
 			clientEvent.getClient().updateLastTransfer();
+			notifyAfterEventSent(clientEvent, null);
 		}
-		notifyAfterEventSent(clientEvent, exception);
-		if (exception != null && logger.isDebugEnabled()) {
-			logger.debug("Synchronous send failed for client " + clientEvent.getClient().getId(), exception);
+		case QUEUED -> {
+			// delivery is accounted asynchronously by the per-client buffer
+		}
+		case DROPPED -> notifyAfterEventDropped(clientEvent);
+		case FAILED -> {
+			notifyAfterEventSent(clientEvent, result.exception);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Synchronous send failed for client " + clientEvent.getClient().getId(), result.exception);
+			}
+		}
 		}
 	}
 
@@ -745,6 +763,15 @@ public class SseEventBus {
 		}
 		catch (Exception e) {
 			logger.error("calling afterEventSent hook failed", e);
+		}
+	}
+
+	private void notifyAfterEventDropped(ClientEvent clientEvent) {
+		try {
+			this.listener.afterEventDropped(clientEvent);
+		}
+		catch (Exception ex) {
+			logger.error("calling afterEventDropped hook failed", ex);
 		}
 	}
 
@@ -806,14 +833,19 @@ public class SseEventBus {
 				}
 				if (clientEvent.getErrorCounter() < this.noOfSendResponseTries) {
 					Client client = clientEvent.getClient();
-					@Nullable Exception e = sendEventToClient(clientEvent);
-					if (e == null) {
+					SendResult result = sendEventToClient(clientEvent);
+					switch (result.outcome) {
+					case SENT -> {
 						client.updateLastTransfer();
 						notifyAfterEventSent(clientEvent, null);
 					}
-					else {
+					case QUEUED -> {
+						// delivery is accounted asynchronously by the per-client buffer
+					}
+					case DROPPED -> notifyAfterEventDropped(clientEvent);
+					case FAILED -> {
 						clientEvent.incErrorCounter();
-						notifyAfterEventSent(clientEvent, e);
+						notifyAfterEventSent(clientEvent, result.exception);
 						if (clientEvent.getErrorCounter() >= this.noOfSendResponseTries) {
 							String clientId = client.getId();
 							unregisterClient(clientId);
@@ -822,6 +854,7 @@ public class SseEventBus {
 						else {
 							offerRetry(clientEvent);
 						}
+					}
 					}
 				}
 				else {
@@ -839,7 +872,7 @@ public class SseEventBus {
 		}
 	}
 
-	private @Nullable Exception sendEventToClient(ClientEvent clientEvent) {
+	private SendResult sendEventToClient(ClientEvent clientEvent) {
 		SseEventBusObservationContext observationContext = createObservationContext(Operation.SEND_EVENT);
 		observationContext.setClientId(clientEvent.getClient().getId());
 		observationContext.setEventName(clientEvent.getSseEvent().event());
@@ -851,19 +884,87 @@ public class SseEventBus {
 		Observation observation = startObservation(observationContext);
 		try (Observation.Scope ignored = observation.openScope()) {
 			useObservationScope(ignored);
-			@Nullable Exception exception = doSendEventToClient(clientEvent);
-			observationContext.setOutcome(exception == null ? "success" : "error");
-			if (exception != null) {
-				observation.error(exception);
+			SendResult result = doSendEventToClient(clientEvent);
+			switch (result.outcome) {
+			case SENT, QUEUED -> observationContext.setOutcome("success");
+			case DROPPED -> observationContext.setOutcome("dropped");
+			case FAILED -> {
+				observationContext.setOutcome("error");
+				Exception exception = result.exception;
+				if (exception != null) {
+					observation.error(exception);
+				}
 			}
-			return exception;
+			}
+			return result;
 		}
 		finally {
 			observation.stop();
 		}
 	}
 
-	private static @Nullable Exception doSendEventToClient(ClientEvent clientEvent) {
+	/**
+	 * Outcome of a single event delivery attempt.
+	 */
+	private enum SendOutcome {
+
+		/**
+		 * The event was written to the connection.
+		 */
+		SENT,
+
+		/**
+		 * The event was enqueued into a per-client send buffer; delivery is reported
+		 * asynchronously by the buffer's dispatcher thread.
+		 */
+		QUEUED,
+
+		/**
+		 * The event was dropped because the client's send buffer was full
+		 * ({@link OverflowPolicy#DROP}).
+		 */
+		DROPPED,
+
+		/**
+		 * Delivery failed.
+		 */
+		FAILED
+
+	}
+
+	/**
+	 * Result of a delivery attempt.
+	 */
+	private static final class SendResult {
+
+		private final SendOutcome outcome;
+
+		private final @Nullable Exception exception;
+
+		private SendResult(SendOutcome outcome, @Nullable Exception exception) {
+			this.outcome = outcome;
+			this.exception = exception;
+		}
+
+		static SendResult sent() {
+			return new SendResult(SendOutcome.SENT, null);
+		}
+
+		static SendResult queued() {
+			return new SendResult(SendOutcome.QUEUED, null);
+		}
+
+		static SendResult dropped() {
+			return new SendResult(SendOutcome.DROPPED, null);
+		}
+
+		static SendResult failed(Exception exception) {
+			return new SendResult(SendOutcome.FAILED, exception);
+		}
+
+	}
+
+	private static SendResult doSendEventToClient(ClientEvent clientEvent) {
 		Client client = clientEvent.getClient();
 		try {
 			SseEmitter emitter;
@@ -876,18 +977,21 @@ public class SseEventBus {
 			}
 			if (sendBuffer != null) {
 				// per-client bounded buffer: the dedicated dispatcher thread writes the
-				// event to the emitter, overflow is handled by the configured policy
-				sendBuffer.offer(clientEvent.createSseEventBuilder());
-				return null;
+				// event to the emitter, delivery is accounted asynchronously
+				return switch (sendBuffer.offer(clientEvent)) {
+				case ACCEPTED -> SendResult.queued();
+				case DROPPED -> SendResult.dropped();
+				case DISCONNECTED, CLOSED -> SendResult.failed(new java.io.IOException("client send buffer closed"));
+				};
 			}
 			emitter.send(clientEvent.createSseEventBuilder());
 			if (completeAfterMessage) {
 				emitter.complete();
 			}
-			return null;
+			return SendResult.sent();
 		}
 		catch (java.io.IOException | RuntimeException e) {
-			return e;
+			return SendResult.failed(e);
 		}
 
 	}
@@ -903,12 +1007,25 @@ public class SseEventBus {
 						if (client.isCompleteAfterMessage()) {
 							emitter.complete();
 						}
+					}, new ClientSendBuffer.DeliveryListener() {
+						@Override
+						public void delivered(ClientEvent event) {
+							client.updateLastTransfer();
+							notifyAfterEventSent(event, null);
+						}
+
+						@Override
+						public void failed(ClientEvent event, Exception exception) {
+							notifyAfterEventSent(event, exception);
+						}
 					}, () -> unregisterClient(client.getId()), this.slowClientListener, this.backpressureMetrics);
-			client.updateSendBuffer(buffer);
-			buffer.start();
+			// Register the queue gauge before the buffer becomes visible to the send
+			// workers to avoid a registration race with an early disconnect
 			if (this.backpressureMetrics != null) {
 				this.backpressureMetrics.registerQueueGauge(client.getId(), buffer::queueSize);
 			}
+			client.updateSendBuffer(buffer);
+			buffer.start();
 		}
 	}
 

--- a/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
@@ -445,7 +445,9 @@ public class SseEventBus {
 				return existing;
 			});
 			Client client = this.clients.get(clientId);
-			setupClientSendBuffer(client);
+			if (client != null) {
+				setupClientSendBuffer(client);
+			}
 			if (this.replayEnabled) {
 				this.replayLocks.computeIfAbsent(clientId, k -> new ReentrantLock());
 			}

--- a/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
@@ -43,6 +43,7 @@ import ch.rasc.sse.eventbus.observation.DefaultSseEventBusObservationConvention;
 import ch.rasc.sse.eventbus.observation.SseEventBusObservationContext;
 import ch.rasc.sse.eventbus.observation.SseEventBusObservationContext.Operation;
 import ch.rasc.sse.eventbus.observation.SseEventBusObservationConvention;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
@@ -99,6 +100,14 @@ public class SseEventBus {
 	private final boolean replayEnabled;
 
 	private final int sendWorkerCount;
+
+	private final int clientSendBufferCapacity;
+
+	private final OverflowPolicy overflowPolicy;
+
+	private final SlowClientListener slowClientListener;
+
+	private final @Nullable SseBackpressureMetrics backpressureMetrics;
 
 	private final @Nullable ReplayStore replayStore;
 
@@ -187,6 +196,14 @@ public class SseEventBus {
 		this.replayEnabled = replayStore != null;
 		this.replayRetention = configurer.replayRetention();
 		this.replayCleanupJobDelay = configurer.replayCleanupJobDelay();
+		this.clientSendBufferCapacity = configurer.clientSendBufferCapacity();
+		this.overflowPolicy = configurer.overflowPolicy();
+		this.slowClientListener = configurer.slowClientListener();
+		MeterRegistry meterRegistry = configurer.meterRegistry();
+		this.backpressureMetrics = meterRegistry != null ? new SseBackpressureMetrics(meterRegistry) : null;
+		if (this.backpressureMetrics != null) {
+			this.backpressureMetrics.registerActiveClientsGauge(this::countSendBuffers);
+		}
 		this.observationRegistry = observationRegistry != null ? observationRegistry : ObservationRegistry.NOOP;
 		this.observationConvention = observationConvention != null ? observationConvention
 				: DEFAULT_OBSERVATION_CONVENTION;
@@ -244,6 +261,10 @@ public class SseEventBus {
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
+			}
+
+			for (Client client : this.clients.values()) {
+				closeClientSendBuffer(client);
 			}
 
 			// Flush remaining events after the event loop has stopped
@@ -423,6 +444,8 @@ public class SseEventBus {
 				}
 				return existing;
 			});
+			Client client = this.clients.get(clientId);
+			setupClientSendBuffer(client);
 			if (this.replayEnabled) {
 				this.replayLocks.computeIfAbsent(clientId, k -> new ReentrantLock());
 			}
@@ -480,6 +503,7 @@ public class SseEventBus {
 			this.clients.compute(clientId, (id, client) -> {
 				if (client != null) {
 					removedEmitter.set(client.sseEmitter());
+					closeClientSendBuffer(client);
 				}
 				this.subscriptionRegistry.unsubscribeAll(id);
 				removePendingEvents(id);
@@ -842,9 +866,17 @@ public class SseEventBus {
 		try {
 			SseEmitter emitter;
 			boolean completeAfterMessage;
+			ClientSendBuffer sendBuffer;
 			synchronized (client) {
 				emitter = client.sseEmitter();
 				completeAfterMessage = client.isCompleteAfterMessage();
+				sendBuffer = client.sendBuffer();
+			}
+			if (sendBuffer != null) {
+				// per-client bounded buffer: the dedicated dispatcher thread writes the
+				// event to the emitter, overflow is handled by the configured policy
+				sendBuffer.offer(clientEvent.createSseEventBuilder());
+				return null;
 			}
 			emitter.send(clientEvent.createSseEventBuilder());
 			if (completeAfterMessage) {
@@ -856,6 +888,47 @@ public class SseEventBus {
 			return e;
 		}
 
+	}
+
+	private void setupClientSendBuffer(Client client) {
+		closeClientSendBuffer(client);
+		int capacity = this.clientSendBufferCapacity;
+		if (capacity > 0) {
+			ClientSendBuffer buffer = new ClientSendBuffer(client.getId(), capacity, this.overflowPolicy,
+					builder -> {
+						SseEmitter emitter = client.sseEmitter();
+						emitter.send(builder);
+						if (client.isCompleteAfterMessage()) {
+							emitter.complete();
+						}
+					}, () -> unregisterClient(client.getId()), this.slowClientListener, this.backpressureMetrics);
+			client.updateSendBuffer(buffer);
+			buffer.start();
+			if (this.backpressureMetrics != null) {
+				this.backpressureMetrics.registerQueueGauge(client.getId(), buffer::queueSize);
+			}
+		}
+	}
+
+	private void closeClientSendBuffer(Client client) {
+		ClientSendBuffer buffer = client.sendBuffer();
+		if (buffer != null) {
+			buffer.close();
+			client.updateSendBuffer(null);
+			if (this.backpressureMetrics != null) {
+				this.backpressureMetrics.removeQueueGauge(client.getId());
+			}
+		}
+	}
+
+	private int countSendBuffers() {
+		int count = 0;
+		for (Client client : this.clients.values()) {
+			if (client.sendBuffer() != null) {
+				count++;
+			}
+		}
+		return count;
 	}
 
 	private @Nullable String convertObject(SseEvent event) {
@@ -889,6 +962,7 @@ public class SseEventBus {
 				this.clients.computeIfPresent(clientId, (id, client) -> {
 					if (client.lastTransfer() < recheckExpiration) {
 						removedEmitter.set(client.sseEmitter());
+						closeClientSendBuffer(client);
 						this.subscriptionRegistry.unsubscribeAll(id);
 						removePendingEvents(id);
 						clearReplayEvents(id);

--- a/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
@@ -280,11 +280,19 @@ public class SseEventBus {
 			}
 
 			// Gracefully deliver events already accepted into per-client send buffers,
-			// then close the buffers
+			// then close the buffers. Draining is started for all buffers in parallel
+			// and bounded by a single shared deadline.
 			for (Client client : this.clients.values()) {
 				ClientSendBuffer buffer = client.sendBuffer();
 				if (buffer != null) {
-					buffer.drain(1000);
+					buffer.startDraining();
+				}
+			}
+			long drainDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+			for (Client client : this.clients.values()) {
+				ClientSendBuffer buffer = client.sendBuffer();
+				if (buffer != null) {
+					buffer.awaitDrained(drainDeadline);
 				}
 			}
 			for (Client client : this.clients.values()) {

--- a/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
+++ b/src/main/java/ch/rasc/sse/eventbus/SseEventBus.java
@@ -278,28 +278,30 @@ public class SseEventBus {
 			if (!remaining.isEmpty()) {
 				logger.info("SseEventBus flushed " + remaining.size() + " pending events on shutdown");
 			}
-
-			// Gracefully deliver events already accepted into per-client send buffers,
-			// then close the buffers. Draining is started for all buffers in parallel
-			// and bounded by a single shared deadline.
-			for (Client client : this.clients.values()) {
-				ClientSendBuffer buffer = client.sendBuffer();
-				if (buffer != null) {
-					buffer.startDraining();
-				}
-			}
-			long drainDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
-			for (Client client : this.clients.values()) {
-				ClientSendBuffer buffer = client.sendBuffer();
-				if (buffer != null) {
-					buffer.awaitDrained(drainDeadline);
-				}
-			}
-			for (Client client : this.clients.values()) {
-				closeClientSendBuffer(client);
-			}
-			logger.info("SseEventBus shut down");
 		}
+
+		// Gracefully deliver events already accepted into per-client send buffers, then
+		// close the buffers. Per-client buffers are also active in synchronous mode
+		// (taskScheduler == null), so this lifecycle must not be conditional on the
+		// scheduler. Draining is started for all buffers in parallel and bounded by a
+		// single shared deadline.
+		for (Client client : this.clients.values()) {
+			ClientSendBuffer buffer = client.sendBuffer();
+			if (buffer != null) {
+				buffer.startDraining();
+			}
+		}
+		long drainDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+		for (Client client : this.clients.values()) {
+			ClientSendBuffer buffer = client.sendBuffer();
+			if (buffer != null) {
+				buffer.awaitDrained(drainDeadline);
+			}
+		}
+		for (Client client : this.clients.values()) {
+			closeClientSendBuffer(client);
+		}
+		logger.info("SseEventBus shut down");
 	}
 
 	/**
@@ -461,10 +463,12 @@ public class SseEventBus {
 				}
 				return existing;
 			});
-			Client client = this.clients.get(clientId);
-			if (client != null) {
+			// Setup the send buffer under the same atomic map operation so a concurrent
+			// unregister cannot detach the client between the map update and the setup
+			this.clients.computeIfPresent(clientId, (id, client) -> {
 				setupClientSendBuffer(client);
-			}
+				return client;
+			});
 			if (this.replayEnabled) {
 				this.replayLocks.computeIfAbsent(clientId, k -> new ReentrantLock());
 			}
@@ -894,7 +898,8 @@ public class SseEventBus {
 			useObservationScope(ignored);
 			SendResult result = doSendEventToClient(clientEvent);
 			switch (result.outcome) {
-			case SENT, QUEUED -> observationContext.setOutcome("success");
+			case SENT -> observationContext.setOutcome("success");
+			case QUEUED -> observationContext.setOutcome("queued");
 			case DROPPED -> observationContext.setOutcome("dropped");
 			case FAILED -> {
 				observationContext.setOutcome("error");

--- a/src/main/java/ch/rasc/sse/eventbus/config/SseEventBusConfigurer.java
+++ b/src/main/java/ch/rasc/sse/eventbus/config/SseEventBusConfigurer.java
@@ -23,11 +23,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.jspecify.annotations.Nullable;
 
 import ch.rasc.sse.eventbus.Client;
 import ch.rasc.sse.eventbus.ClientEvent;
+import ch.rasc.sse.eventbus.OverflowPolicy;
 import ch.rasc.sse.eventbus.ReplayStore;
+import ch.rasc.sse.eventbus.SlowClientListener;
 import ch.rasc.sse.eventbus.SseEventBusListener;
 
 /**
@@ -176,6 +179,48 @@ public interface SseEventBusConfigurer {
 	 */
 	default Duration replayCleanupJobDelay() {
 		return replayRetention();
+	}
+
+	/**
+	 * Optional capacity of a bounded per-client send buffer. When greater than zero
+	 * every client gets its own bounded queue with a dedicated dispatcher thread.
+	 * Slow clients (for example LLM token streaming consumers that cannot keep up)
+	 * fill their buffer and are handled according to {@link #overflowPolicy()}
+	 * instead of blocking the shared send workers.
+	 * <p>
+	 * Default: -1 (disabled, events are sent through the shared send queue)
+	 */
+	default int clientSendBufferCapacity() {
+		return -1;
+	}
+
+	/**
+	 * Policy applied when a client's send buffer is full.
+	 * <p>
+	 * Default: {@link OverflowPolicy#DROP}
+	 */
+	default OverflowPolicy overflowPolicy() {
+		return OverflowPolicy.DROP;
+	}
+
+	/**
+	 * Listener notified when a client has been detected as slow.
+	 * <p>
+	 * Default: no-op listener
+	 */
+	default SlowClientListener slowClientListener() {
+		return event -> {
+			// nothing here
+		};
+	}
+
+	/**
+	 * Optional Micrometer registry used to record slow client backpressure metrics.
+	 * <p>
+	 * Default: {@code null} (metrics are disabled)
+	 */
+	default @Nullable MeterRegistry meterRegistry() {
+		return null;
 	}
 
 }

--- a/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
@@ -60,14 +60,25 @@ class ClientSendBufferTest {
 
 	@Test
 	void dispatchDeliversEventsInOrder() {
-		List<String> sent = new ArrayList<>();
-		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP, builder -> sent.add(builder.toString()),
-				noopDeliveryListener(), null, null, null);
+		List<String> delivered = new ArrayList<>();
+		DeliveryListener listener = new DeliveryListener() {
+			@Override
+			public void delivered(ClientEvent event) {
+				delivered.add(String.valueOf(event.getSseEvent().data()));
+			}
+
+			@Override
+			public void failed(ClientEvent event, Exception exception) {
+				// nothing here
+			}
+		};
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP, builder -> {
+		}, listener, null, null, null);
 		buffer.start();
 		buffer.offer(clientEvent("c1", "1"));
 		buffer.offer(clientEvent("c1", "2"));
 		buffer.offer(clientEvent("c1", "3"));
-		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(sent).hasSize(3));
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(delivered).containsExactly("1", "2", "3"));
 		buffer.close();
 	}
 

--- a/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -27,6 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
 
+import ch.rasc.sse.eventbus.ClientSendBuffer.DeliveryListener;
+import ch.rasc.sse.eventbus.ClientSendBuffer.EventSink;
+import ch.rasc.sse.eventbus.ClientSendBuffer.OfferResult;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class ClientSendBufferTest {
@@ -35,16 +39,89 @@ class ClientSendBufferTest {
 		return SseEmitter.event().data(data);
 	}
 
+	private static ClientEvent clientEvent(String id, String data) {
+		Client client = new Client(id, new SseEmitter(0L), false);
+		return new ClientEvent(client, SseEvent.of("test", data), data);
+	}
+
+	private static DeliveryListener noopDeliveryListener() {
+		return new DeliveryListener() {
+			@Override
+			public void delivered(ClientEvent event) {
+				// nothing here
+			}
+
+			@Override
+			public void failed(ClientEvent event, Exception exception) {
+				// nothing here
+			}
+		};
+	}
+
 	@Test
 	void dispatchDeliversEventsInOrder() {
 		List<String> sent = new ArrayList<>();
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP, builder -> sent.add(builder.toString()),
-				null, null, null);
+				noopDeliveryListener(), null, null, null);
 		buffer.start();
-		buffer.offer(event("1"));
-		buffer.offer(event("2"));
-		buffer.offer(event("3"));
+		buffer.offer(clientEvent("c1", "1"));
+		buffer.offer(clientEvent("c1", "2"));
+		buffer.offer(clientEvent("c1", "3"));
 		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(sent).hasSize(3));
+		buffer.close();
+	}
+
+	@Test
+	void deliveredIsAccountedAfterSinkRuns() {
+		List<String> sent = new ArrayList<>();
+		List<String> delivered = new ArrayList<>();
+		DeliveryListener listener = new DeliveryListener() {
+			@Override
+			public void delivered(ClientEvent event) {
+				delivered.add(String.valueOf(event.getSseEvent().data()));
+			}
+
+			@Override
+			public void failed(ClientEvent event, Exception exception) {
+				// nothing here
+			}
+		};
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP, builder -> sent.add(builder.toString()),
+				listener, null, null, null);
+		buffer.start();
+		buffer.offer(clientEvent("c1", "1"));
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(delivered).containsExactly("1"));
+		assertThat(sent).hasSize(1);
+		buffer.close();
+	}
+
+	@Test
+	void sinkFailureAccountsFailedAndNotifiesDisconnect() {
+		AtomicBoolean disconnected = new AtomicBoolean();
+		AtomicInteger failedEvents = new AtomicInteger();
+		DeliveryListener listener = new DeliveryListener() {
+			@Override
+			public void delivered(ClientEvent event) {
+				// nothing here
+			}
+
+			@Override
+			public void failed(ClientEvent event, Exception exception) {
+				failedEvents.incrementAndGet();
+			}
+		};
+		EventSink failingSink = builder -> {
+			throw new IOException("connection lost");
+		};
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DROP, failingSink, listener,
+				() -> disconnected.set(true), null, null);
+		buffer.start();
+		buffer.offer(clientEvent("c1", "1"));
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+			assertThat(disconnected).isTrue();
+			assertThat(failedEvents).hasValue(1);
+		});
+		assertThat(buffer.isClosed()).isTrue();
 		buffer.close();
 	}
 
@@ -52,11 +129,11 @@ class ClientSendBufferTest {
 	void dropPolicyRejectsOverflowAndNotifiesListener() {
 		List<SlowClientEvent> slowClientEvents = new ArrayList<>();
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 2, OverflowPolicy.DROP, builder -> {
-		}, null, slowClientEvents::add, null);
+		}, noopDeliveryListener(), null, slowClientEvents::add, null);
 
-		assertThat(buffer.offer(event("1"))).isTrue();
-		assertThat(buffer.offer(event("2"))).isTrue();
-		assertThat(buffer.offer(event("3"))).isFalse();
+		assertThat(buffer.offer(clientEvent("c1", "1"))).isEqualTo(OfferResult.ACCEPTED);
+		assertThat(buffer.offer(clientEvent("c1", "2"))).isEqualTo(OfferResult.ACCEPTED);
+		assertThat(buffer.offer(clientEvent("c1", "3"))).isEqualTo(OfferResult.DROPPED);
 
 		assertThat(buffer.queueSize()).isEqualTo(2);
 		assertThat(buffer.isClosed()).isFalse();
@@ -72,44 +149,53 @@ class ClientSendBufferTest {
 	void disconnectPolicyClosesBufferAndNotifies() {
 		AtomicBoolean disconnected = new AtomicBoolean();
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 1, OverflowPolicy.DISCONNECT, builder -> {
-		}, () -> disconnected.set(true), event -> {
+		}, noopDeliveryListener(), () -> disconnected.set(true), event -> {
 		}, null);
 
-		assertThat(buffer.offer(event("1"))).isTrue();
-		assertThat(buffer.offer(event("2"))).isFalse();
+		assertThat(buffer.offer(clientEvent("c1", "1"))).isEqualTo(OfferResult.ACCEPTED);
+		assertThat(buffer.offer(clientEvent("c1", "2"))).isEqualTo(OfferResult.DISCONNECTED);
 
 		assertThat(buffer.isClosed()).isTrue();
 		assertThat(disconnected).isTrue();
-		assertThat(buffer.offer(event("3"))).isFalse();
+		assertThat(buffer.offer(clientEvent("c1", "3"))).isEqualTo(OfferResult.CLOSED);
 	}
 
 	@Test
-	void offerReturnsFalseAfterClose() {
+	void offerReturnsClosedAfterClose() {
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DROP, builder -> {
-		}, null, null, null);
+		}, noopDeliveryListener(), null, null, null);
 		buffer.close();
-		assertThat(buffer.offer(event("1"))).isFalse();
+		assertThat(buffer.offer(clientEvent("c1", "1"))).isEqualTo(OfferResult.CLOSED);
 	}
 
 	@Test
 	void closeDoesNotNotifyDisconnect() {
 		AtomicBoolean disconnected = new AtomicBoolean();
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DISCONNECT, builder -> {
-		}, () -> disconnected.set(true), null, null);
+		}, noopDeliveryListener(), () -> disconnected.set(true), null, null);
 		buffer.close();
 		assertThat(disconnected).isFalse();
 	}
 
 	@Test
-	void sinkFailureClosesBufferAndNotifiesDisconnect() {
-		AtomicBoolean disconnected = new AtomicBoolean();
-		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DROP, builder -> {
-			throw new IOException("connection lost");
-		}, () -> disconnected.set(true), null, null);
+	void drainDeliversQueuedEvents() {
+		List<String> sent = new ArrayList<>();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP,
+				builder -> {
+					try {
+						Thread.sleep(20);
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					sent.add(builder.toString());
+				}, noopDeliveryListener(), null, null, null);
 		buffer.start();
-		buffer.offer(event("1"));
-		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(disconnected).isTrue());
-		assertThat(buffer.isClosed()).isTrue();
+		buffer.offer(clientEvent("c1", "1"));
+		buffer.offer(clientEvent("c1", "2"));
+		buffer.offer(clientEvent("c1", "3"));
+		buffer.drain(2000);
+		assertThat(sent).hasSize(3);
 		buffer.close();
 	}
 
@@ -118,11 +204,11 @@ class ClientSendBufferTest {
 		SimpleMeterRegistry registry = new SimpleMeterRegistry();
 		SseBackpressureMetrics metrics = new SseBackpressureMetrics(registry);
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 1, OverflowPolicy.DROP, builder -> {
-		}, null, event -> {
+		}, noopDeliveryListener(), null, event -> {
 		}, metrics);
 
-		assertThat(buffer.offer(event("1"))).isTrue();
-		assertThat(buffer.offer(event("2"))).isFalse();
+		assertThat(buffer.offer(clientEvent("c1", "1"))).isEqualTo(OfferResult.ACCEPTED);
+		assertThat(buffer.offer(clientEvent("c1", "2"))).isEqualTo(OfferResult.DROPPED);
 
 		assertThat(registry.get("sse.eventbus.client.buffer.overflow.total").counter().count()).isEqualTo(1);
 		assertThat(registry.get("sse.eventbus.client.buffer.dropped.events").counter().count()).isEqualTo(1);

--- a/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class ClientSendBufferTest {
+
+	private static SseEventBuilder event(String data) {
+		return SseEmitter.event().data(data);
+	}
+
+	@Test
+	void dispatchDeliversEventsInOrder() {
+		List<String> sent = new ArrayList<>();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 10, OverflowPolicy.DROP, builder -> sent.add(builder.toString()),
+				null, null, null);
+		buffer.start();
+		buffer.offer(event("1"));
+		buffer.offer(event("2"));
+		buffer.offer(event("3"));
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(sent).hasSize(3));
+		buffer.close();
+	}
+
+	@Test
+	void dropPolicyRejectsOverflowAndNotifiesListener() {
+		List<SlowClientEvent> slowClientEvents = new ArrayList<>();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 2, OverflowPolicy.DROP, builder -> {
+		}, null, slowClientEvents::add, null);
+
+		assertThat(buffer.offer(event("1"))).isTrue();
+		assertThat(buffer.offer(event("2"))).isTrue();
+		assertThat(buffer.offer(event("3"))).isFalse();
+
+		assertThat(buffer.queueSize()).isEqualTo(2);
+		assertThat(buffer.isClosed()).isFalse();
+		assertThat(slowClientEvents).hasSize(1);
+		SlowClientEvent slowClientEvent = slowClientEvents.get(0);
+		assertThat(slowClientEvent.clientId()).isEqualTo("c1");
+		assertThat(slowClientEvent.policy()).isEqualTo(OverflowPolicy.DROP);
+		assertThat(slowClientEvent.queueSize()).isEqualTo(2);
+		assertThat(slowClientEvent.capacity()).isEqualTo(2);
+	}
+
+	@Test
+	void disconnectPolicyClosesBufferAndNotifies() {
+		AtomicBoolean disconnected = new AtomicBoolean();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 1, OverflowPolicy.DISCONNECT, builder -> {
+		}, () -> disconnected.set(true), event -> {
+		}, null);
+
+		assertThat(buffer.offer(event("1"))).isTrue();
+		assertThat(buffer.offer(event("2"))).isFalse();
+
+		assertThat(buffer.isClosed()).isTrue();
+		assertThat(disconnected).isTrue();
+		assertThat(buffer.offer(event("3"))).isFalse();
+	}
+
+	@Test
+	void offerReturnsFalseAfterClose() {
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DROP, builder -> {
+		}, null, null, null);
+		buffer.close();
+		assertThat(buffer.offer(event("1"))).isFalse();
+	}
+
+	@Test
+	void closeDoesNotNotifyDisconnect() {
+		AtomicBoolean disconnected = new AtomicBoolean();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DISCONNECT, builder -> {
+		}, () -> disconnected.set(true), null, null);
+		buffer.close();
+		assertThat(disconnected).isFalse();
+	}
+
+	@Test
+	void sinkFailureClosesBufferAndNotifiesDisconnect() {
+		AtomicBoolean disconnected = new AtomicBoolean();
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 5, OverflowPolicy.DROP, builder -> {
+			throw new IOException("connection lost");
+		}, () -> disconnected.set(true), null, null);
+		buffer.start();
+		buffer.offer(event("1"));
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(disconnected).isTrue());
+		assertThat(buffer.isClosed()).isTrue();
+		buffer.close();
+	}
+
+	@Test
+	void recordsMetricsOnOverflow() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		SseBackpressureMetrics metrics = new SseBackpressureMetrics(registry);
+		ClientSendBuffer buffer = new ClientSendBuffer("c1", 1, OverflowPolicy.DROP, builder -> {
+		}, null, event -> {
+		}, metrics);
+
+		assertThat(buffer.offer(event("1"))).isTrue();
+		assertThat(buffer.offer(event("2"))).isFalse();
+
+		assertThat(registry.get("sse.eventbus.client.buffer.overflow.total").counter().count()).isEqualTo(1);
+		assertThat(registry.get("sse.eventbus.client.buffer.dropped.events").counter().count()).isEqualTo(1);
+		assertThat(registry.get("sse.eventbus.client.buffer.slow.client.notifications").counter().count()).isEqualTo(1);
+	}
+
+}

--- a/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/ClientSendBufferTest.java
@@ -142,13 +142,17 @@ class ClientSendBufferTest {
 		ClientSendBuffer buffer = new ClientSendBuffer("c1", 2, OverflowPolicy.DROP, builder -> {
 		}, noopDeliveryListener(), null, slowClientEvents::add, null);
 
+		// Fill the buffer while the dispatcher is not running to keep the queue size
+		// deterministic, then start it so the pending notification is delivered
 		assertThat(buffer.offer(clientEvent("c1", "1"))).isEqualTo(OfferResult.ACCEPTED);
 		assertThat(buffer.offer(clientEvent("c1", "2"))).isEqualTo(OfferResult.ACCEPTED);
 		assertThat(buffer.offer(clientEvent("c1", "3"))).isEqualTo(OfferResult.DROPPED);
 
 		assertThat(buffer.queueSize()).isEqualTo(2);
 		assertThat(buffer.isClosed()).isFalse();
-		assertThat(slowClientEvents).hasSize(1);
+
+		buffer.start();
+		await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(slowClientEvents).hasSize(1));
 		SlowClientEvent slowClientEvent = slowClientEvents.get(0);
 		assertThat(slowClientEvent.clientId()).isEqualTo("c1");
 		assertThat(slowClientEvent.policy()).isEqualTo(OverflowPolicy.DROP);
@@ -223,7 +227,13 @@ class ClientSendBufferTest {
 
 		assertThat(registry.get("sse.eventbus.client.buffer.overflow.total").counter().count()).isEqualTo(1);
 		assertThat(registry.get("sse.eventbus.client.buffer.dropped.events").counter().count()).isEqualTo(1);
-		assertThat(registry.get("sse.eventbus.client.buffer.slow.client.notifications").counter().count()).isEqualTo(1);
+
+		buffer.start();
+		await().atMost(Duration.ofSeconds(2))
+			.untilAsserted(() -> assertThat(
+					registry.get("sse.eventbus.client.buffer.slow.client.notifications").counter().count())
+				.isEqualTo(1));
+		buffer.close();
 	}
 
 }

--- a/src/test/java/ch/rasc/sse/eventbus/SseEventBusBackpressureDisconnectTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/SseEventBusBackpressureDisconnectTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import ch.rasc.sse.eventbus.config.EnableSseEventBus;
+import ch.rasc.sse.eventbus.config.SseEventBusConfigurer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+@ContextConfiguration
+@DirtiesContext
+@SpringJUnitConfig
+class SseEventBusBackpressureDisconnectTest {
+
+	private static final ConcurrentMap<String, Client> CLIENTS_MAP = new ConcurrentHashMap<>();
+
+	private static final List<SlowClientEvent> SLOW_CLIENT_EVENTS = new CopyOnWriteArrayList<>();
+
+	private static final MeterRegistry REGISTRY = new SimpleMeterRegistry();
+
+	@Configuration
+	@EnableSseEventBus
+	static class Config implements SseEventBusConfigurer {
+
+		@Override
+		public int clientSendBufferCapacity() {
+			return 2;
+		}
+
+		@Override
+		public OverflowPolicy overflowPolicy() {
+			return OverflowPolicy.DISCONNECT;
+		}
+
+		@Override
+		public SlowClientListener slowClientListener() {
+			return SLOW_CLIENT_EVENTS::add;
+		}
+
+		@Override
+		public MeterRegistry meterRegistry() {
+			return REGISTRY;
+		}
+
+		@Override
+		public ConcurrentMap<String, Client> clients() {
+			return CLIENTS_MAP;
+		}
+
+		@Override
+		public int noOfSendResponseTries() {
+			return 1;
+		}
+
+	}
+
+	@Autowired
+	private SseEventBus eventBus;
+
+	@BeforeEach
+	void cleanup() {
+		SLOW_CLIENT_EVENTS.clear();
+		for (String clientId : this.eventBus.getAllClientIds()) {
+			this.eventBus.unregisterClient(clientId);
+		}
+	}
+
+	@Test
+	void disconnectPolicyDisconnectsSlowClient() {
+		SseEmitter slowEmitter = new SlowSseEmitter();
+		this.eventBus.registerClient("slow", slowEmitter);
+		this.eventBus.subscribe("slow", "test");
+		for (int i = 0; i < 50; i++) {
+			this.eventBus.handleEvent(SseEvent.of("test", "msg-" + i));
+		}
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(this.eventBus.getAllClientIds()).doesNotContain("slow");
+			assertThat(SLOW_CLIENT_EVENTS).isNotEmpty();
+		});
+		assertThat(REGISTRY.get("sse.eventbus.client.buffer.disconnected.clients").counter().count()).isGreaterThan(0);
+	}
+
+	static class SlowSseEmitter extends SseEmitter {
+
+		SlowSseEmitter() {
+			super(0L);
+		}
+
+		@Override
+		public void send(SseEventBuilder builder) throws IOException {
+			try {
+				Thread.sleep(50);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			super.send(builder);
+		}
+
+	}
+
+}

--- a/src/test/java/ch/rasc/sse/eventbus/SseEventBusBackpressureDropTest.java
+++ b/src/test/java/ch/rasc/sse/eventbus/SseEventBusBackpressureDropTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.rasc.sse.eventbus;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import ch.rasc.sse.eventbus.config.EnableSseEventBus;
+import ch.rasc.sse.eventbus.config.SseEventBusConfigurer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+@ContextConfiguration
+@DirtiesContext
+@SpringJUnitConfig
+class SseEventBusBackpressureDropTest {
+
+	private static final ConcurrentMap<String, Client> CLIENTS_MAP = new ConcurrentHashMap<>();
+
+	private static final List<SlowClientEvent> SLOW_CLIENT_EVENTS = new CopyOnWriteArrayList<>();
+
+	private static final MeterRegistry REGISTRY = new SimpleMeterRegistry();
+
+	@Configuration
+	@EnableSseEventBus
+	static class Config implements SseEventBusConfigurer {
+
+		@Override
+		public int clientSendBufferCapacity() {
+			return 2;
+		}
+
+		@Override
+		public OverflowPolicy overflowPolicy() {
+			return OverflowPolicy.DROP;
+		}
+
+		@Override
+		public SlowClientListener slowClientListener() {
+			return SLOW_CLIENT_EVENTS::add;
+		}
+
+		@Override
+		public MeterRegistry meterRegistry() {
+			return REGISTRY;
+		}
+
+		@Override
+		public ConcurrentMap<String, Client> clients() {
+			return CLIENTS_MAP;
+		}
+
+		@Override
+		public int noOfSendResponseTries() {
+			return 1;
+		}
+
+	}
+
+	@Autowired
+	private SseEventBus eventBus;
+
+	@BeforeEach
+	void cleanup() {
+		SLOW_CLIENT_EVENTS.clear();
+		for (String clientId : this.eventBus.getAllClientIds()) {
+			this.eventBus.unregisterClient(clientId);
+		}
+	}
+
+	@Test
+	void dropPolicyDropsEventsForSlowClient() {
+		this.eventBus.registerClient("slow", new SlowSseEmitter());
+		this.eventBus.subscribe("slow", "test");
+		for (int i = 0; i < 50; i++) {
+			this.eventBus.handleEvent(SseEvent.of("test", "msg-" + i));
+		}
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(SLOW_CLIENT_EVENTS).isNotEmpty());
+		assertThat(REGISTRY.get("sse.eventbus.client.buffer.dropped.events").counter().count()).isGreaterThan(0);
+		assertThat(REGISTRY.get("sse.eventbus.client.buffer.overflow.total").counter().count()).isGreaterThan(0);
+		// DROP policy keeps the connection open
+		assertThat(this.eventBus.getAllClientIds()).contains("slow");
+		this.eventBus.unregisterClient("slow");
+	}
+
+	static class SlowSseEmitter extends SseEmitter {
+
+		SlowSseEmitter() {
+			super(0L);
+		}
+
+		@Override
+		public void send(SseEventBuilder builder) throws IOException {
+			try {
+				Thread.sleep(50);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			super.send(builder);
+		}
+
+	}
+
+}


### PR DESCRIPTION
### Motivation

Slow clients — for example LLM token streaming consumers that cannot keep up — can fill the shared send queue and block **all** send workers (head-of-line blocking). Every other client then experiences latency even though their own connections are healthy.

### What this PR adds

An **optional bounded per-client send buffer** with a dedicated dispatcher thread per client:

- Every client gets its own `LinkedBlockingQueue` with a configurable capacity and its own daemon thread (`sse-client-send-<clientId>`) that writes events to that client's `SseEmitter`.
- The shared send workers only enqueue into the bounded buffer (non-blocking `offer`), so a slow client can no longer stall the event loop.
- When the buffer is full, the configured **overflow policy** applies:
  - `OverflowPolicy.DROP` — drop the new event, keep the connection open (client may miss events while slow).
  - `OverflowPolicy.DISCONNECT` — close the connection and unregister the slow client; the client can reconnect later.
- In both cases a `SlowClientListener` callback is invoked with a `SlowClientEvent` (clientId, policy, queueSize, capacity, detail, timestamp) so the application can degrade event frequency, alert, or throttle publishing.
- Optional Micrometer metrics are recorded when a `MeterRegistry` is provided.

### Configuration (all default to the previous behaviour)

```java
@Configuration
@EnableSseEventBus
public class MyConfig implements SseEventBusConfigurer {

    @Override
    public int clientSendBufferCapacity() {
        return 128;          // > 0 enables the per-client buffer; default -1 (disabled)
    }

    @Override
    public OverflowPolicy overflowPolicy() {
        return OverflowPolicy.DROP;   // or DISCONNECT
    }

    @Override
    public SlowClientListener slowClientListener() {
        return event -> log.warn("slow client {} ({}), {} of {} queued",
                event.clientId(), event.policy(), event.queueSize(), event.capacity());
    }

    @Override
    public MeterRegistry meterRegistry() {
        return registry;      // e.g. Micrometer's global registry
    }
}
```

### Metrics (prefix `sse.eventbus.client.buffer`)

| Name | Type | Description |
| --- | --- | --- |
| `overflow.total` | Counter | number of buffer overflows |
| `dropped.events` | Counter | events dropped by the DROP policy |
| `disconnected.clients` | Counter | clients disconnected by the DISCONNECT policy |
| `slow.client.notifications` | Counter | slow client callback invocations |
| `queue.size` | Gauge (tag `clientId`) | currently queued events per client |
| `active.clients` | Gauge | number of clients with an active send buffer |

### Tests

- `ClientSendBufferTest` — unit tests for ordered delivery, DROP/DISCONNECT overflow handling, close semantics, sink failure handling and metrics.
- `SseEventBusBackpressureDropTest` — integration test: a slow emitter (50 ms per send) overflows the buffer, events are dropped, the listener is notified and the connection stays open.
- `SseEventBusBackpressureDisconnectTest` — integration test: the slow client is disconnected and unregistered when the DISCONNECT policy is configured.

`mvn verify` passes (all existing tests + new tests, spring-javaformat, license check).

### Notes

- The buffer is disabled by default (`clientSendBufferCapacity() = -1`), so existing applications keep exactly the previous behaviour.
- The per-client buffer complements the existing shared `sendQueue` (producer-side backpressure): it adds per-consumer isolation on top of it.
